### PR TITLE
fix(client) wrong config used for GSR data

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -156,7 +156,7 @@ local function playerShootingLoop()
             if IsPedShooting(cache.ped) then
                 shotsFired += 1
 
-                if shotsFired > sharedConfig.statuses.gsr.threshold and not recentlyGSR and math.random() <= config.statuses.gsr.chance then
+                if shotsFired > sharedConfig.statuses.gsr.threshold and not recentlyGSR and math.random() <= sharedConfig.statuses.gsr.chance then
                     TriggerServerEvent('qbx_evidence:server:setGSR')
 
                     recentlyGSR = true


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes nil value error as `config` is incorrectly referenced rather than `sharedConfig` which contains the GSR config.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
